### PR TITLE
Fix/vim validate deprecation

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -727,9 +727,8 @@ function alpha.start(on_vimenter, conf)
 end
 
 function alpha.setup(config)
-    vim.validate({
-        config = { config, "table" },
-        layout = { config.layout, "table" },
+    vim.validate("config", config, "table")
+    vim.validate("layout", config.layout, "table")
     })
 
     config.opts = vim.tbl_extend(

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -729,7 +729,6 @@ end
 function alpha.setup(config)
     vim.validate("config", config, "table")
     vim.validate("layout", config.layout, "table")
-    })
 
     config.opts = vim.tbl_extend(
         "keep",

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -727,8 +727,8 @@ function alpha.start(on_vimenter, conf)
 end
 
 function alpha.setup(config)
-    vim.validate("config", config, "table")
-    vim.validate("layout", config.layout, "table")
+    vim.validate("config", config, "table", false)
+    vim.validate("layout", config.layout, "table", false)
 
     config.opts = vim.tbl_extend(
         "keep",


### PR DESCRIPTION
This PR fixes a deprecation warning from Neovim related to `vim.validate`.

- Replaces old `vim.validate({...})` call with the new 4-argument signature.
- Ensures compatibility with upcoming Neovim 0.12 and 1.0 versions.

## Checkhealth:
```
==============================================================================
vim.deprecated:                       require("vim.deprecated.health").check()

 ~
- ⚠️ WARNING vim.validate is deprecated. Feature will be removed in Nvim 1.0
  - ADVICE:
    - stack traceback:
        /Users/dimasprabowo/.local/share/nvim/site/pack/packer/start/alpha-nvim/lua/alpha.lua:730
        /Users/dimasprabowo/.config/nvim/lua/98prabowo/plugins/dashboard.lua:78
        [C]:-1
        /Users/dimasprabowo/.config/nvim/init.lua:13
```